### PR TITLE
Some minor build fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
 
-  # 
+  #
   # nginx, working as a front-end proxy for uniqush
   # we need it for only allowing certain endpoints to be available
   nginx:
@@ -59,8 +59,7 @@ services:
 
   # uniqush itself
   uniqush:
-      build:
-          context: docker-uniqush
+      build: https://github.com/beevelop/docker-uniqush.git
       environment:
           # this is the default, but let's be explicit here
           UNIQUSH_DATABASE_HOST: "redis"
@@ -82,4 +81,3 @@ services:
       volumes:
           - "./.docker/redis:/data"
       command: ["redis-server", "--appendonly", "yes"]
-  

--- a/maintence-scripts/setup.sh
+++ b/maintence-scripts/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash          
+#!/bin/bash
 
 function kill_docker_containers {
   echo -e "\n\e[94mStopping any errantly running docker containers\e[0m"
@@ -8,7 +8,7 @@ function kill_docker_containers {
 }
 
 echo "Setting up a new Push server..."
- 
+
 # Ask the email of the main user
 
 while true
@@ -30,7 +30,7 @@ do
     fi
   fi
 done
- 
+
 # Ask the name of the site
 
 while true
@@ -87,7 +87,7 @@ kill_docker_containers
 # Create the proper ssl certs
 echo -e "\n\e[94mCreating SSL certificates\e[0m"
 echo -e "\e[94m---------------------------------\e[0m\n"
-docker-compose -f letsencrypt-docker-compose.yml up
+docker-compose -f ../letsencrypt-docker-compose.yml up
 
 # Stop any possible docker-compose containers that might be sticking around
 kill_docker_containers

--- a/maintence-scripts/setup.sh
+++ b/maintence-scripts/setup.sh
@@ -87,7 +87,11 @@ kill_docker_containers
 # Create the proper ssl certs
 echo -e "\n\e[94mCreating SSL certificates\e[0m"
 echo -e "\e[94m---------------------------------\e[0m\n"
-docker-compose -f ../letsencrypt-docker-compose.yml up
+if basename "$PWD" | grep 'maintence-scripts' > /dev/null; then
+  docker-compose -f ../letsencrypt-docker-compose.yml up
+else
+  docker-compose -f letsencrypt-docker-compose.yml up
+fi
 
 # Stop any possible docker-compose containers that might be sticking around
 kill_docker_containers

--- a/maintence-scripts/setup.sh
+++ b/maintence-scripts/setup.sh
@@ -38,13 +38,13 @@ do
   echo -en "What is the host name for this installation (e.g. testapp.pushapp.press)? "
   read host
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    if ! echo "$host" | grep -qiE "^[A-z]*[\.]*[A-z]+[\.][A-z]+$" ;then
+    if ! echo "$host" | grep -qiE "^[A-z0-9]*[\.]*[A-z0-9]+[\.][A-z]{2,}+$" ;then
       echo -e "\e[91mNot a valid URL format. Please try again.\e[0m"
     else
       break
     fi
   else
-    if ! echo "$host" | grep -qiP "^[A-z]*[\.]*[A-z]+[\.][A-z]+$" ;then
+    if ! echo "$host" | grep -qiP "^[A-z0-9]*[\.]*[A-z0-9]+[\.][A-z]{2,}+$" ;then
       echo -e "\e[91mNot a valid URL format. Please try again.\e[0m"
     else
       break


### PR DESCRIPTION
* Adds the full URL to `docker-uniqush` in the `docker-compose.yml` file, otherwise `docker-compose` fails to fetch it.
* `maintenance-scripts/setup.sh` referred to `letsencrypt-docker-compose.yml` from the `maintenance-scripts` directory instead of the root project directory, causing Let's Encrypt process not to get executed.
* Expands the `grep` used when asked for the name of the site to allow numbers in a domain. This allows me to use `<X>.r3bl.me`, something I can't use without it. Reference for further expansion: http://stackoverflow.com/questions/1418423/the-hostname-regex