### PR TITLE
Checks if Docker and docker-compose are available right at the beginning of the script

### DIFF
--- a/docker-compose-no-nginx.yml
+++ b/docker-compose-no-nginx.yml
@@ -1,0 +1,56 @@
+version: '2'
+services:
+
+  #
+  # nginx, working as a front-end proxy for uniqush
+  # we need it for only allowing certain endpoints to be available
+  db:
+    image: postgres
+    volumes:
+      - "./.docker/postgres:/data/postgres"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - PGDATA=/data/postgres
+
+  web:
+    build: .
+    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    volumes:
+      - .:/push
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+      - uniqush
+    env_file:
+      - ./secrets.env
+    environment:
+      - RAILS_ENV=${RAILS_ENV}
+      - proxy_images=true
+    entrypoint: /push/entrypoint.sh
+    tty: true
+    stdin_open: true
+
+  # uniqush itself
+  uniqush:
+      build: https://github.com/beevelop/docker-uniqush.git
+      environment:
+          # this is the default, but let's be explicit here
+          UNIQUSH_DATABASE_HOST: "redis"
+#          UNIQUSH_LOGFILE:       "/srv/logs/gurac/uniqush.log"
+          UNIQUSH_LOGLEVEL:      "verbose"
+          UNIQUSH_GID:           "60001"
+          UNIQUSH_UID:           "60001"
+      depends_on:
+          - redis
+      volumes:
+          - "./secrets:/secrets"
+          #- "/srv/logs/gurac/:/srv/logs/gurac/"
+
+  # the redis db server
+  redis:
+      image: redis
+      volumes:
+          - "./.docker/redis:/data"
+      command: ["redis-server", "--appendonly", "yes"]

--- a/maintence-scripts/cms_cleaner.sh
+++ b/maintence-scripts/cms_cleaner.sh
@@ -1,0 +1,336 @@
+#!/bin/bash
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/includes.sh"
+
+# This is the setup script for to easily create a secrets.env file for a Push Backend Server.
+
+# I have no idea how to pass in variables to a bash function, figure that out.
+# This will just stub otherwise
+function check_host_resolution {
+  echo -e "Check that \e[96m$host\e[0m resolves properly..."
+  curl -H $host
+  #check that headers are 200, 404, 502 (maybe 500?) everything that's not 'did not resolve'
+}
+
+# Generates a secret key long enough and unique enough for devise and rails
+function generate_secret_key {
+  dd if=/dev/random bs=64 count=1 2>/dev/null | od -An -tx1 | tr -d ' \t\n'
+}
+
+
+
+# Checks the prerequisites
+echoc "\n-------------------------------------------------------------------------------------------------------------\n" $LIGHT_BLUE
+echoc "Checking prerequisites..."
+command -v docker >/dev/null 2>&1 || { echoc "This script requires docker to continue. Aborting." $RED >&2; exit 1; }
+command -v docker-compose >/dev/null 2>&1 || { echoc "This script requires docker-compose to continue. Aborting." $RED >&2; exit 1; }
+echoc "Everything needed for this wizard to run is available. Continuing with the process..." $LIGHT_BLUE
+echoc "\n-------------------------------------------------------------------------------------------------------------\n" $LIGHT_BLUE
+
+
+echoc "\n-------------------------------------------------------------------------------------------------------------\n" $LIGHT_BLUE
+echoc "Here we'll be creating all the settings that lets your server talk to your CMS..."
+echoc "\n-------------------------------------------------------------------------------------------------------------\n" $LIGHT_BLUE
+
+echoc "First, what type of CMS do you have?\n"
+# bash options list?
+PS3='Please enter your choice: '
+options=("WordPress" "Newscoop" "Joomla!" "Codeignitor")
+select opt in "${options[@]}"
+do
+    case $opt in
+        "WordPress")
+            cms='Wordpress';
+            break
+            ;;
+        "Newscoop")
+            cms='Newscoop';
+            break
+            ;;
+        "Joomla!")
+            cms='Joomla';
+            break
+            ;;
+        "Codeignitor")
+            cms='Codeignitor';
+            break
+            ;;
+        *) echo invalid option;;
+    esac
+done
+
+echoc "Setting up a $cms installation" $GREEN
+
+# Ask the name of the of the site
+while true
+do
+  echo -en "What is the full name of your organization? (e.g. The Sample News)? "
+  read title
+  if ! [[ -z "${title// }" ]]; then
+    break
+  else
+    echoc "You must type in the name of an Organization." $RED
+  fi
+done
+
+# Ask the web address of the main cms of the site
+while true
+do
+  echo -en "What is the web address of your $cms CMS (e.g. https://www.mycms.com)? "
+  read cms_address
+  regex='(https?)://[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|]'
+  if ! [[ $cms_address =~ $regex ]]
+  then
+    echoc "Please try again with a valid URL." $RED
+  else
+    break
+  fi
+done
+
+# Ask the name of the site
+echoc "\nNext we'll ask for the host name."
+echoc "This requires that your host name resolves to this server."
+echoc "Please see the README.md if you need more info or you're not sure what that means.\n"
+
+while true
+do
+  echo -en "What is the host name for this installation (e.g. testapp.pushapp.press)? "
+  read host
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    if ! echo "$host" | egrep -qiE "^[A-z0-9]*[\.]*[A-z0-9]+[\.][A-z]{2,}$" ;then
+      echoc "Sorry, I can't seem to parse your url because it's not a valid URL format. Please try again." $RED
+    else
+      break
+    fi
+  else
+    if ! echo "$host" | grep -qiP "^[A-z0-9]*[\.]*[A-z0-9]+[\.][A-z]{2,}$" ;then
+      echoc "Sorry, I can't seem to parse your url because it's not a valid URL format. Please try again." $RED
+    else
+      break
+    fi
+  fi
+done
+
+# Ask if they use google search for their cms
+echoc "\nDoes your CMS use Google to handle its search functionality [yN]?"
+echoc "The answer is probably no, but if your unsure do a search on your site,"
+echoc "if there's a Google logo you probably do.\n"
+
+google_search=$(askyn "Do you use Google Search?" $google_search)
+
+# If they use google search ask for the google search id
+if [ "$google_search" = true ]; then
+  echo "Since you use Google search for your CMS, we need the search engine id."
+  if [[ $cms == 'Wordpress' ]]; then
+    echo "You can probably find this in the settings in your Wordpress search plugin."
+    echo "You can find more information about this in the README.md appendix section."
+  fi
+
+  while true
+  do
+    echo -en "What is the Google Search Engine ID? "
+    read google_search_engine_id
+
+    if [[ -z "${google_search_engine_id// }" ]]; then
+      echoc "Please type in a Google Search Engine ID."
+    else
+      break
+    fi
+  done
+fi
+
+# If wordpress
+if [[ $cms == 'Wordpress' ]]; then
+
+  # If they use the wp_super_cached_donotcachepage plugin (it's rare)
+  echo "Does your Wordpress installation use the WP Super Cache plugin?"
+  echo "There will be an entry underneathe your Wordpress's 'Settings' menu."
+  echo "You can find more information about this in the README.md appendix section."
+
+  supercache=$(askyn 'Does your Wordpress plugin use the WP Super Cache Plugin?')
+
+  if [ "$supercache" = true ]; then
+    # If wordpress && supercache
+
+    # If they use the wp_super_cached_donotcachepage plugin (it's rare)
+    echo "Does your Wordpress Super Cache installation use 'donotcache' feature?"
+    # Check out Bivol's installation
+    echo "It is a feature that must be enabled under the do not cache page."
+
+    donotcacheplugin=$(askyn 'Does your Wordpress Super Cache installation use 'donotcache' feature?')
+
+    if [ "$donotcacheplugin" = true ]; then
+      # If wordpress && supercache && wordpress_super_cache_donotcachepage
+
+      # If they use the wp_super_cached_donotcachepage plugin (it's rare)
+      echo "What is the hash key for the donotcache feature?"
+      # Check out Bivol's installation
+      echo "There will be an entry underneathe your Wordpress's 'Settings' menu."
+      echo "You can find more information about this in the README.md appendix section."
+
+      while true
+      do
+        echo -en "What is the the donotcache hash key? "
+        read donotcacheplugin_hash
+
+        if [[ -z "${donotcacheplugin_hash// }" ]]; then
+          echoc "Please type in a Do Not Cache hash key."
+        else
+          break
+        fi
+      done
+
+    fi
+  fi
+fi
+
+# Ask for languages
+echo "What langauges does your app provide?\n"
+echo "We currently support:"
+echo "Azerbaijani (az)"
+echo "Bulgarian (bg)"
+echo "English (en)"
+echo "Georigan (ha)" # check this
+echo "Romanian (ro)"
+echo "Russian (ru)"
+echo "Serbian (sr)"
+
+echo "Your app can support as many as you want, but must support at least one."
+languages=()
+language_options=("Azerbaijani" "Bulgarian" "English" "Georigan" "Romanian" "Russian" "Serbian" "Finished Choosing Languages")
+
+while true
+do
+  finish=false
+  echo "Choose a language to add to your app. "
+  PS3='Please enter your choice: '
+  select opt in "${language_options[@]}"
+  do
+      case $opt in
+          "Azerbaijani")
+              languages+=('az')
+              break
+              ;;
+          "Bulgarian")
+              languages+=('bg')
+              break
+              ;;
+          "English")
+              languages+=('en')
+              break
+              ;;
+          "Georigan")
+              languages+=('ha')
+              break
+              ;;
+          "Romanian")
+              languages+=('ro')
+              break
+              ;;
+          "Russian")
+              languages+=('ru')
+              break
+              ;;
+          "Serbian")
+              languages+=('sr')
+              break
+              ;;
+          "Finished Choosing Languages")
+              if ! [[ ${#languages[@]} == 0 ]]; then
+                finish=true
+              fi
+              break
+              ;;
+          *) echo invalid option;;
+      esac
+  done
+
+  if [ "$finish" = true ]; then
+    if [[ ${#languages[@]} == 0 ]] ; then
+      echoc "\nPlease choose at least one language for your app.\n" $RED
+    else
+      break
+    fi
+  fi
+
+  index=0
+  for language in ${language_options[@]}; do
+        echo "$language"
+        if [ "$language" = "$opt" ]; then
+            unset language_options[$index]
+            echo "language_options is now: ${language_options[@]}"
+            break
+        fi
+        let index++
+  done
+
+
+done
+
+# ask for the default language, if there's more than one
+if [[ ${#languages[@]} == 1 ]] ; then
+  default_language=$languages[0]
+else
+  echo "Please choose a default language. "
+  select opt in "${languages[@]}"
+  do
+    default_language=$opt
+    break
+  done
+fi
+
+
+# join the language strings Here
+languages=$(join_by , "${languages[@]}")
+echo $languages
+# check if secrets.env exists and prompt if it does
+if basename "$PWD" | grep 'maintence-scripts' > /dev/null; then
+  path='../secrets.env'
+else
+  path='secrets.env'
+fi
+
+if [ ! -f $path ]; then
+    echoc "No secrets.env file found, creating it." $YELLOW
+else
+  replace_env=$(askyn "Found current secrets.env file. Should I replace it?")
+  if [ "$replace_env" = true ]; then
+    echoc "Removing current secrets.env file" $YELLOW
+    rm $path
+  else
+    exit
+  fi
+fi
+
+echoc "Creating new secrets.env file" $YELLOW
+touch $path
+
+# Write the secrets.env file
+echoc "Creating secrets.env file" $GREEN
+
+cms_mode=$(echo "$cms" | tr '[:upper:]' '[:lower:]')
+cat <<EOT >> secrets.env
+#########################################
+#
+# Configuration for the Push Backend
+# This file was automatically generated
+#
+#########################################
+
+title="$title"
+cms_mode=$cms_mode
+$(echo "$cms_mode")_url=$cms_address
+force_https=true
+google_search_engine_id=$google_search_engine_id
+DEVISE_SECRET_KEY=$(generate_secret_key)
+SECRET_KEY_BASE=$(generate_secret_key)
+wp_super_cached_donotcachepage=$wp_super_cached_donotcachepage
+proxy_images=true
+host=$host
+languages="$languages"
+default_language=$default_language
+
+EOT
+
+echo "Finished! If they're already running, please restart your docker containers to update them."

--- a/maintence-scripts/setup-cms_env.sh
+++ b/maintence-scripts/setup-cms_env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash          
+#!/bin/bash
 DIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 . "$DIR/includes.sh"
@@ -18,6 +18,14 @@ function generate_secret_key {
   dd if=/dev/random bs=64 count=1 2>/dev/null | od -An -tx1 | tr -d ' \t\n'
 }
 
+
+
+# Checks the prerequisites
+echoc "Checking prerequisites..."
+command -v docker >/dev/null 2>&1 || { echoc "This script requires docker to continue. Aborting." $RED >&2; exit 1; }
+command -v docker-compose >/dev/null 2>&1 || { echoc "This script requires docker-compose to continue. Aborting." $RED >&2; exit 1; }
+echoc "Everything needed for this wizard to run is available. Continuing with the process..."
+echoc "\n-------------------------------------------------------------------------------------------------------------\n" $LIGHT_BLUE
 
 echoc "Here we'll be creating all the settings that lets your server talk to your CMS..."
 echoc "\n-------------------------------------------------------------------------------------------------------------\n" $LIGHT_BLUE
@@ -109,7 +117,7 @@ echoc "if there's a Google logo you probably do.\n"
 google_search=$(askyn "Do you use Google Search?" $google_search)
 
 # If they use google search ask for the google search id
-if [ "$google_search" = true ]; then 
+if [ "$google_search" = true ]; then
   echo "Since you use Google search for your CMS, we need the search engine id."
   if [[ $cms == 'Wordpress' ]]; then
     echo "You can probably find this in the settings in your Wordpress search plugin."
@@ -120,7 +128,7 @@ if [ "$google_search" = true ]; then
   do
     echo -en "What is the Google Search Engine ID? "
     read google_search_engine_id
-    
+
     if [[ -z "${google_search_engine_id// }" ]]; then
       echoc "Please type in a Google Search Engine ID."
     else
@@ -132,27 +140,27 @@ fi
 # If wordpress
 if [[ $cms == 'Wordpress' ]]; then
 
-  # If they use the wp_super_cached_donotcachepage plugin (it's rare) 
+  # If they use the wp_super_cached_donotcachepage plugin (it's rare)
   echo "Does your Wordpress installation use the WP Super Cache plugin?"
   echo "There will be an entry underneathe your Wordpress's 'Settings' menu."
   echo "You can find more information about this in the README.md appendix section."
 
   supercache=$(askyn 'Does your Wordpress plugin use the WP Super Cache Plugin?')
 
-  if [ "$supercache" = true ]; then 
+  if [ "$supercache" = true ]; then
     # If wordpress && supercache
 
-    # If they use the wp_super_cached_donotcachepage plugin (it's rare) 
+    # If they use the wp_super_cached_donotcachepage plugin (it's rare)
     echo "Does your Wordpress Super Cache installation use 'donotcache' feature?"
     # Check out Bivol's installation
     echo "It is a feature that must be enabled under the do not cache page."
 
     donotcacheplugin=$(askyn 'Does your Wordpress Super Cache installation use 'donotcache' feature?')
 
-    if [ "$donotcacheplugin" = true ]; then 
+    if [ "$donotcacheplugin" = true ]; then
       # If wordpress && supercache && wordpress_super_cache_donotcachepage
 
-      # If they use the wp_super_cached_donotcachepage plugin (it's rare) 
+      # If they use the wp_super_cached_donotcachepage plugin (it's rare)
       echo "What is the hash key for the donotcache feature?"
       # Check out Bivol's installation
       echo "There will be an entry underneathe your Wordpress's 'Settings' menu."
@@ -162,7 +170,7 @@ if [[ $cms == 'Wordpress' ]]; then
       do
         echo -en "What is the the donotcache hash key? "
         read donotcacheplugin_hash
-        
+
         if [[ -z "${donotcacheplugin_hash// }" ]]; then
           echoc "Please type in a Do Not Cache hash key."
         else
@@ -235,8 +243,8 @@ do
       esac
   done
 
-  if [ "$finish" = true ]; then 
-    if [[ ${#languages[@]} == 0 ]] ; then  
+  if [ "$finish" = true ]; then
+    if [[ ${#languages[@]} == 0 ]] ; then
       echoc "\nPlease choose at least one language for your app.\n" $RED
     else
       break
@@ -267,7 +275,7 @@ else
     default_language=$opt
     break
   done
-fi  
+fi
 
 
 # join the language strings Here

--- a/maintence-scripts/setup-locally.sh
+++ b/maintence-scripts/setup-locally.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# A script to spin up Push servers on a local server (without relying on AWS), in a multiple instance
+# server setup.
+# Author: Aleksandar Todorović
+# Date: January 25th, 2017
+# Contact: aleksandar@r3bl.me
+
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/includes.sh"
+
+# This would break a lot of things in the multi-website hosting scenario
+
+#function kill_docker_containers {
+#  echo -e "\n\e[94mStopping any errantly running docker containers\e[0m"
+#  echo -e "\e[94m---------------------------------\e[0m\n"
+#  docker stop $(docker ps -a -q)
+#  docker rm $(docker ps -a -q)
+#}
+
+echoc "\n-------------------------------------------------------------------------------------------------------------\n" $LIGHT_BLUE
+echoc "Setting up a new Push server..." $LIGHT_BLUE
+echoc "\n-------------------------------------------------------------------------------------------------------------\n" $LIGHT_BLUE
+
+if basename "$PWD" | grep 'maintence-scripts' > /dev/null; then
+  path='./cms_cleaner.sh'
+else
+  path='./maintence-scripts/cms_cleaner.sh'
+fi
+
+bash $path
+
+if [ "$?" = 0 ]; then
+  echoc '\n---------------------------------------------------------\n' $LIGHT_BLUE
+  echoc "    Theoretically you\'re done!!!\n" $LIGHT_BLUE
+  echoc "Run \"docker-compose -f ../docker-compose-no-nginx.yml up\" to make sure everything's fine. \n" $LIGHT_BLUE
+  echoc '\n---------------------------------------------------------\n' $LIGHT_BLUE
+else
+  echoc '\n---------------------------------------------------------' $RED
+  echoc "It looks like there were some errors. I'm sorry about that, I know it can be frustrating"
+  echoc "Please review any messages and post bug reports if you believe it's an inapproriate error."
+  echoc '---------------------------------------------------------' $RED
+fi


### PR DESCRIPTION
If `docker-compose` and/or `docker` is/are not available, the setup script will still continue and the message:

```
Everything should be set up properly now. Try running docker-compose up to make sure it works.
```

...will _still_ get triggered, which could cause the confusion. This check sees if the commands are available and, if they are, starts the wizard. 

I may be the only one who got confused by this, hence the submission as a PR.